### PR TITLE
Drop support for net5 to allow System.Diagnostics.DiagnosticSource > 7.0.1

### DIFF
--- a/ci/templates/build-and-package.yml
+++ b/ci/templates/build-and-package.yml
@@ -8,12 +8,6 @@ steps:
     inputs:
       version: 6.x
       includePreviewVersions: false
-
-  
-  - task: UseDotNet@2
-    inputs:
-      version: 5.x
-      includePreviewVersions: true
       
   - task: DotNetCoreCLI@2
     displayName: "Restore packages"

--- a/src/Honeycomb.Serilog.Sink/Honeycomb.Serilog.Sink.csproj
+++ b/src/Honeycomb.Serilog.Sink/Honeycomb.Serilog.Sink.csproj
@@ -25,10 +25,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[5.0.1,7.0.1)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net7.0;net6.0;net5.0;</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(IsWindows) == true">$(TargetFrameworks);net462;net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Honeycomb.Serilog.Sink.Tests/Honeycomb.Serilog.Sink.Tests.csproj
+++ b/test/Honeycomb.Serilog.Sink.Tests/Honeycomb.Serilog.Sink.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -22,8 +22,8 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' AND '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The hard version dependency on System.Diagnostics.DiagnosticSource <= 7.0.1 is causing update problems due to version mismatches in our latest internal net7 projects. This PR drops the out of support net5.0 framework in order to allow DiagnosticSource >= 7.0.2., as well as updating all the package dependencies to their latest versions.