### PR TITLE
Fix potential null reference exception from stalling the sink

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
-    "version": "7.0.103",
+    "version": "9.0.304",
     "allowPrerelease": true,
     "rollForward": "latestMinor"
   }
 }
+

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Build">
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/src/Honeycomb.Serilog.Sink/Formatters/RawJsonFormatter.cs
+++ b/src/Honeycomb.Serilog.Sink/Formatters/RawJsonFormatter.cs
@@ -43,8 +43,11 @@ namespace Honeycomb.Serilog.Sink.Formatters
                 JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.GetType().ToString(), output);
                 output.Write(",\"exception.message\":");
                 JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
-                output.Write(",\"exception.stacktrace\":");
-                JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.StackTrace, output);
+                if (logEvent.Exception.StackTrace != null)
+                {
+                    output.Write(",\"exception.stacktrace\":");
+                    JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.StackTrace, output);
+                }
             }
 
             if (logEvent.Properties.Any())

--- a/src/Honeycomb.Serilog.Sink/Honeycomb.Serilog.Sink.csproj
+++ b/src/Honeycomb.Serilog.Sink/Honeycomb.Serilog.Sink.csproj
@@ -22,13 +22,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="4.3.0">
+    <PackageReference Include="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.9" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/Honeycomb.Serilog.Sink/Honeycomb.Serilog.Sink.csproj
+++ b/src/Honeycomb.Serilog.Sink/Honeycomb.Serilog.Sink.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
     <Title>Honeycomb Serilog sink</Title>
     <PackageTags>Honeycomb Serilog Sink Observability Logging Monitoring</PackageTags>
     <RepositoryUrl>https://github.com/evilpilaf/HoneycombSerilogSink/</RepositoryUrl>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,8 +2,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(IsWindows) == true">$(TargetFrameworks);net462;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(IsWindows) == true">$(TargetFrameworks);net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Honeycomb.Serilog.Sink.Tests/Honeycomb.Serilog.Sink.Tests.csproj
+++ b/test/Honeycomb.Serilog.Sink.Tests/Honeycomb.Serilog.Sink.Tests.csproj
@@ -4,17 +4,18 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="FluentAssertions" Version="8.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
 </Project>

--- a/test/Honeycomb.Serilog.Sink.Tests/Honeycomb.Serilog.Sink.Tests.csproj
+++ b/test/Honeycomb.Serilog.Sink.Tests/Honeycomb.Serilog.Sink.Tests.csproj
@@ -1,5 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />


### PR DESCRIPTION
In my .net 9 project the sink can sometimes throw a null reference exception here, which seems to stall the sink and no logs get emitted to honeycomb after that.

This fix defends against that, and it seems to have fixed my issue.
